### PR TITLE
Updating image URLs to use the imgproxy

### DIFF
--- a/src/views/Campout/Home.js
+++ b/src/views/Campout/Home.js
@@ -16,32 +16,32 @@ const content = [
   {
     title: 'Enthralling Visions',
     subtitle: 'Be ready for BAAAHS light wizardry set to full face-melt mode, nestled cutely amongst the trees. There ain’t no party like a BAAAHS party bb!!',
-    img: { src: 'https://storage.googleapis.com/static.baaahs.org/dark_rainbow_pasture.png' },
+    img: { src: 'https://static.baaahs.org/Z/dark_rainbow_pasture.png' },
   },
   {
     title: 'Enchanting Aurals',
     subtitle: 'Two stages and three nights of BAAAHS-rockin\' beats from your fav BAAAHS DJs and special guests on our world class sound system!',
-    img: { src: 'https://storage.googleapis.com/static.baaahs.org/ben_dancing_lights.png' },
+    img: { src: 'https://static.baaahs.org/Z/ben_dancing_lights.png' },
   },
   {
     title: 'Alluring Art',
     subtitle: 'Art is core to BAAAHS and we work hard to bring queer art from the Bay Area and beyond to our campout. Want to bring art? Let us know, we may be able to help with materials and logistics!',
-    img: { src: 'https://storage.googleapis.com/static.baaahs.org/simon_art_piece.png' },
+    img: { src: 'https://static.baaahs.org/Z/simon_art_piece.png' },
   },
   {
     title: 'Into the Woods',
     subtitle: 'Hosted at The Incline, a new queer-owned retreat space in the mountains near the Mendocino National Forest, serving majestic views, lush camping, and extensive trails to explore.',
-    img: { src: 'https://storage.googleapis.com/static.baaahs.org/mendocino_view.jpeg', style: { width: undefined, height: '120%' } },
+    img: { src: 'https://static.baaahs.org/Z/mendocino_view.jpeg', style: { width: undefined, height: '120%' } },
   },
   {
     title: 'Participate and Play',
     subtitle: 'The weekend is packed with amazing parties and activities from nature hikes to screen printing, and our infamous talent expo, and they all need YOU! This is the place to try something new and leave that judgement at the gate.',
-    img: { src: 'https://storage.googleapis.com/static.baaahs.org/crafts.jpeg' },
+    img: { src: 'https://static.baaahs.org/Z/crafts.jpeg' },
   },
   {
     title: 'Creating Community',
     subtitle: 'BAAAHS Campout is a place to find happiness not in things we have or things we need, but in our community and in the simple joy of being present.',
-    img: { src: 'https://storage.googleapis.com/static.baaahs.org/trixie_and_friends.jpeg' },
+    img: { src: 'https://static.baaahs.org/Z/trixie_and_friends.jpeg' },
   },
 ];
 
@@ -67,8 +67,8 @@ const CampoutHome = () => {
       <Box gap={3}>
         <FullScreenHeader
           title={'BAAAHS Campout'}
-          image='https://storage.googleapis.com/static.baaahs.org/PXL_20230416_022706111.jpeg'
-          logo='https://storage.googleapis.com/static.baaahs.org/campout_logo_no_border.png'
+          image='https://static.baaahs.org/Z/PXL_20230416_022706111.jpeg'
+          logo='https://static.baaahs.org/Z/campout_logo_no_border.png'
           text={
             <Button
               component={'a'}

--- a/src/views/Campout/LastYear.js
+++ b/src/views/Campout/LastYear.js
@@ -12,129 +12,129 @@ import NavItems from './NavItems';
 
 const contentItems = [
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230527_174212.jpg',
+    src: 'https://static.baaahs.org/Z/20230527_174212.jpg',
     cols: 3,
     rows: 2,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/IMG_0448.png',
+    src: 'https://static.baaahs.org/Z/IMG_0448.png',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230527_174339.jpg',
+    src: 'https://static.baaahs.org/Z/20230527_174339.jpg',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230528_004535.jpg',
+    src: 'https://static.baaahs.org/Z/20230528_004535.jpg',
     cols: 2,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230529_002733.jpg',
+    src: 'https://static.baaahs.org/Z/20230529_002733.jpg',
     cols: 3,
     rows: 2,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230528_174740.jpg',
+    src: 'https://static.baaahs.org/Z/20230528_174740.jpg',
     cols: 3,
     rows: 2,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230528_004629.jpg',
+    src: 'https://static.baaahs.org/Z/20230528_004629.jpg',
     cols: 2,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230528_172118.jpg',
+    src: 'https://static.baaahs.org/Z/20230528_172118.jpg',
     cols: 3,
     rows: 2,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230528_232605.jpg',
+    src: 'https://static.baaahs.org/Z/20230528_232605.jpg',
     cols: 3,
     rows: 2,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230528_065034.jpg',
+    src: 'https://static.baaahs.org/Z/20230528_065034.jpg',
     cols: 3,
     rows: 2,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230528_172109.jpg',
+    src: 'https://static.baaahs.org/Z/20230528_172109.jpg',
     cols: 3,
     rows: 2,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230528_052014.jpg',
+    src: 'https://static.baaahs.org/Z/20230528_052014.jpg',
     cols: 3,
     rows: 2,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/20230528_051741.jpg',
+    src: 'https://static.baaahs.org/Z/20230528_051741.jpg',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/afik_hugging.jpg',
+    src: 'https://static.baaahs.org/Z/afik_hugging.jpg',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/baaahs_dark_sign.jpg',
+    src: 'https://static.baaahs.org/Z/baaahs_dark_sign.jpg',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/dark_rainbow_pasture.png',
+    src: 'https://static.baaahs.org/Z/dark_rainbow_pasture.png',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/eric_and_phillip.png',
+    src: 'https://static.baaahs.org/Z/eric_and_phillip.png',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/mendocino_view_1.jpg',
+    src: 'https://static.baaahs.org/Z/mendocino_view_1.jpg',
     cols: 4,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/pasture_lights_c%26j.jpeg',
+    src: 'https://static.baaahs.org/Z/pasture_lights_c%26j.jpeg',
     cols: 4,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/pasture_preview_lights.mov',
+    src: 'https://static.baaahs.org/pasture_preview_lights.mov',
     cols: 4,
     rows: 3,
     isVideo: true,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/pelican.jpg',
+    src: 'https://static.baaahs.org/Z/pelican.jpg',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/shae_green.jpg',
+    src: 'https://static.baaahs.org/Z/shae_green.jpg',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/the_grove_lights_preview.mov',
+    src: 'https://static.baaahs.org/the_grove_lights_preview.mov',
     cols: 3,
     rows: 4,
     isVideo: true,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/the_pasture_crowd.jpg',
+    src: 'https://static.baaahs.org/Z/the_pasture_crowd.jpg',
     cols: 3,
     rows: 3,
   },
   {
-    src: 'https://storage.googleapis.com/static.baaahs.org/the_pasture_wide_shot.jpg',
+    src: 'https://static.baaahs.org/Z/the_pasture_wide_shot.jpg',
     cols: 3,
     rows: 3,
   },
@@ -149,7 +149,7 @@ const LastYear = () => {
       <Box gap={3}>
         <FullScreenHeader
           image={
-            'https://storage.googleapis.com/static.baaahs.org/drag_bingpo_candid0.jpeg'
+            'https://static.baaahs.org/Z/drag_bingpo_candid0.jpeg'
           }
           title={'Previous Years'}
           text={

--- a/src/views/Campout/QAndA.js
+++ b/src/views/Campout/QAndA.js
@@ -82,7 +82,7 @@ const QAndA = () => {
       <Box gap={3}>
         <FullScreenHeader
           image={
-            'https://storage.googleapis.com/static.baaahs.org/twunkerbell_backshot.jpeg'
+            'https://static.baaahs.org/Z/twunkerbell_backshot.jpeg'
           }
           title={'Q&A'}
           text={'Your questions, our answers!'}

--- a/src/views/Campout/WhatToExpect.js
+++ b/src/views/Campout/WhatToExpect.js
@@ -12,7 +12,7 @@ const content = [
     header: 'The Incline',
     body: 'The Incline is situated in the mountains of the Mendocino National Forest. You’ll have views for days, plus more like: a pool, multiple indoor and outdoor party spaces, lots of campsites, fancy outdoor shower, and beautiful forest trails.',
     img: {
-      src: 'https://storage.googleapis.com/static.baaahs.org/mendocino_view.jpeg',
+      src: 'https://static.baaahs.org/Z/mendocino_view.jpeg',
       height: 380,
       width: '100%',
     },
@@ -21,7 +21,7 @@ const content = [
     header: 'Pure Queer Fun',
     body: 'Other than parties, we put on events through the week like Drag Bingo, a No-Talent Show, arts and crafts, and more! Lots of opportunities for folks to really express themselves and share it with the world.',
     img: {
-      src: 'https://storage.googleapis.com/static.baaahs.org/eric_and_phillip.png',
+      src: 'https://static.baaahs.org/Z/eric_and_phillip.png',
       height: '100%',
       width: '100%',
       round: true,
@@ -31,7 +31,7 @@ const content = [
     header: 'Iconic BAAAHS Lights and Sound',
     body: 'Our parties are some of the best in the Bay Area and we bring it to you on a mountain. BAAAHS DJs and friends will be spinning till sunrise, and you can expect some of the same technology powering our art car to decorate the canopy of trees as you’re dancing your ass off.',
     img: {
-      src: 'https://storage.googleapis.com/static.baaahs.org/dark_rainbow_pasture.png',
+      src: 'https://static.baaahs.org/Z/dark_rainbow_pasture.png',
       height: '100%',
       width: '100%',
     },
@@ -40,7 +40,7 @@ const content = [
     header: 'Family Meals',
     body: 'We serve breakfast and dinner every day and it’s campout tradition that we all sit down together to enjoy your meal. After all, you’re part of the BAAAHS family now.',
     img: {
-      src: 'https://storage.googleapis.com/static.baaahs.org/drag_bingo_pan.png',
+      src: 'https://static.baaahs.org/Z/drag_bingo_pan.png',
       height: '100%',
       width: '100%',
     },
@@ -49,7 +49,7 @@ const content = [
     header: 'Gear Transport',
     body: 'We are weary of too many cars going up on the narrow road up to the Incline. So we offer to transport your camping gear for you free of charge! With the extra space in everyone’s vehicles, we strongly encourage folks to offer space in their vehicle leading up to the event. We will announce drop-off and pick-up locations in San Francisco closer to the event and carpool sign up soon.',
     img: {
-      src: 'https://storage.googleapis.com/static.baaahs.org/yotam_mood.png',
+      src: 'https://static.baaahs.org/Z/yotam_mood.png',
       height: '100%',
       width: '100%',
     },
@@ -58,7 +58,7 @@ const content = [
     header: 'Camping',
     body: 'We are sleeping (mostly) in tents folks! There will be some campsite power for charging phones and lights, but nothing crazy. There are also VERY LIMITED RV passes available at extra cost.',
     img: {
-      src: 'https://storage.googleapis.com/static.baaahs.org/Baaahs-camp%20out-fire-fb.png',
+      src: 'https://static.baaahs.org/Z/Baaahs-camp%20out-fire-fb.png',
       height: '100%',
       width: '100%',
     },
@@ -79,7 +79,7 @@ const WhatToExpect = () => {
       <Box gap={3}>
         <FullScreenHeader
           image={
-            'https://storage.googleapis.com/static.baaahs.org/drag_bingo_pan.png'
+            'https://static.baaahs.org/Z/drag_bingo_pan.png'
           }
           title={'What To Expect'}
           text={

--- a/src/views/IndexView/components/Events/Events.js
+++ b/src/views/IndexView/components/Events/Events.js
@@ -29,7 +29,7 @@ const Events = () => {
       <HorizontallyAlignedBlogCardWithShapedImage
         data={{
           image:
-            'https://storage.googleapis.com/static.baaahs.org/campout_logo_promo.png',
+            'https://static.baaahs.org/Z/campout_logo_promo.png',
           description:
             'A campout put on by BAAAHS and friends over Memorial Day weekend. We’ve been putting it on for three years now and excited for our fourth! Our campouts are known for being whimsical, community driven, silly, and of course a whole lot of queer fun. We aim to create a safe space for self-expression, creativity and kindness. Live music, sparkle-tastic lights, dance parties, group events, art and other surprises included. Eccentric outfits, gifting and showing off the best of you is strongly encouraged. And much like Burning Man, it is a Leave No Trace event.',
           title: 'BAAAHS Campout 2024 - WHAAAT?',

--- a/src/views/IndexView/components/Hero/Hero.js
+++ b/src/views/IndexView/components/Hero/Hero.js
@@ -12,36 +12,17 @@ const images = [
     group: [
       {
         cover:
-          'https://storage.googleapis.com/static.baaahs.org/2013_sheep.jpeg',
+          'https://static.baaahs.org/Z/2013_sheep.jpeg',
         coverDark: undefined,
       },
       {
         cover:
-          'https://storage.googleapis.com/static.baaahs.org/2015_sheep.jpeg',
+          'https://static.baaahs.org/Z/2015_sheep.jpeg',
         coverDark: undefined,
       },
       {
         cover:
-          'https://storage.googleapis.com/static.baaahs.org/shady_xian_discoballs.jpeg',
-        coverDark: undefined,
-      },
-    ],
-  },
-  {
-    group: [
-      {
-        cover:
-          'https://storage.googleapis.com/static.baaahs.org/2019_sheep.jpeg',
-        coverDark: undefined,
-      },
-      {
-        cover:
-          'https://storage.googleapis.com/static.baaahs.org/rainbow_baaahs.png',
-        coverDark: undefined,
-      },
-      {
-        cover:
-          'https://storage.googleapis.com/static.baaahs.org/sunset_balls_sheep.jpeg',
+          'https://static.baaahs.org/Z/shady_xian_discoballs.jpeg',
         coverDark: undefined,
       },
     ],
@@ -50,17 +31,36 @@ const images = [
     group: [
       {
         cover:
-          'https://storage.googleapis.com/static.baaahs.org/2019_sheep_2.jpeg',
+          'https://static.baaahs.org/Z/2019_sheep.jpeg',
         coverDark: undefined,
       },
       {
         cover:
-          'https://storage.googleapis.com/static.baaahs.org/build_sheep.jpeg',
+          'https://static.baaahs.org/Z/rainbow_baaahs.png',
         coverDark: undefined,
       },
       {
         cover:
-          'https://storage.googleapis.com/static.baaahs.org/kinky_sheep.jpeg',
+          'https://static.baaahs.org/Z/sunset_balls_sheep.jpeg',
+        coverDark: undefined,
+      },
+    ],
+  },
+  {
+    group: [
+      {
+        cover:
+          'https://static.baaahs.org/Z/2019_sheep_2.jpeg',
+        coverDark: undefined,
+      },
+      {
+        cover:
+          'https://static.baaahs.org/Z/build_sheep.jpeg',
+        coverDark: undefined,
+      },
+      {
+        cover:
+          'https://static.baaahs.org/Z/kinky_sheep.jpeg',
         coverDark: undefined,
       },
       {

--- a/src/views/IndexView/components/TenPrinciples/TenPrinciples.js
+++ b/src/views/IndexView/components/TenPrinciples/TenPrinciples.js
@@ -12,61 +12,61 @@ const principles = [
     title: 'Radical Inclusion',
     subtitle:
       'Anyone may be a part of Burning Man. We welcome and respect the stranger. No prerequisites exist for participation in our community.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-radical-inclusion.png'
+    icon: 'https://static.baaahs.org/Z/wick-radical-inclusion.png'
   },
   {
     title: 'Gifting',
     subtitle:
       'Burning Man is devoted to acts of gift giving. The value of a gift is unconditional. Gifting does not contemplate a return or an exchange for something of equal value.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-gifting.png',
+    icon: 'https://static.baaahs.org/Z/wick-gifting.png',
   },
   {
     title: 'Decommo-dification',
     subtitle:
       'In order to preserve the spirit of gifting, our community seeks to create social environments that are unmediated by commercial sponsorships, transactions, or advertising. We stand ready to protect our culture from such exploitation. We resist the substitution of consumption for participatory experience.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-decommodification.png',
+    icon: 'https://static.baaahs.org/Z/wick-decommodification.png',
   },
   {
     title: 'Radical Self-reliance',
     subtitle:
       'Burning Man encourages the individual to discover, exercise and rely on their inner resources.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-radical-self-reliance.png',
+    icon: 'https://static.baaahs.org/Z/wick-radical-self-reliance.png',
   },
   {
     title: 'Radical Self-expression',
     subtitle:
       'Radical self-expression arises from the unique gifts of the individual. No one other than the individual or a collaborating group can determine its content. It is offered as a gift to others. In this spirit, the giver should respect the rights and liberties of the recipient.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-radical-self-expression.png',
+    icon: 'https://static.baaahs.org/Z/wick-radical-self-expression.png',
   },
   {
     title: 'Communal Effort',
     subtitle:
       'Our community values creative cooperation and collaboration. We strive to produce, promote and protect social networks, public spaces, works of art, and methods of communication that support such interaction.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-communal-effort.png',
+    icon: 'https://static.baaahs.org/Z/wick-communal-effort.png',
   },
   {
     title: 'Civic Responsibility',
     subtitle:
       'We value civil society. Community members who organize events should assume responsibility for public welfare and endeavor to communicate civic responsibilities to participants. They must also assume responsibility for conducting events in accordance with local, state and federal laws.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-civic-responsibility.png',
+    icon: 'https://static.baaahs.org/Z/wick-civic-responsibility.png',
   },
   {
     title: 'Leaving No Trace',
     subtitle:
       'Our community respects the environment. We are committed to leaving no physical trace of our activities wherever we gather. We clean up after ourselves and endeavor, whenever possible, to leave such places in a better state than when we found them.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-leaving-no-trace.png',
+    icon: 'https://static.baaahs.org/Z/wick-leaving-no-trace.png',
   },
   {
     title: 'Participation',
     subtitle:
       'Our community is committed to a radically participatory ethic. We believe that transformative change, whether in the individual or in society, can occur only through the medium of deeply personal participation. We achieve being through doing. Everyone is invited to work. Everyone is invited to play. We make the world real through actions that open the heart.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-participation.png',
+    icon: 'https://static.baaahs.org/Z/wick-participation.png',
   },
   {
     title: 'Immediacy',
     subtitle:
       'Immediate experience is, in many ways, the most important touchstone of value in our culture. We seek to overcome barriers that stand between us and a recognition of our inner selves, the reality of those around us, participation in society, and contact with a natural world exceeding human powers. No idea can substitute for this experience.',
-    icon: 'https://storage.googleapis.com/static.baaahs.org/wick-immediacy.png',
+    icon: 'https://static.baaahs.org/Z/wick-immediacy.png',
   },
 ];
 

--- a/src/views/NotFoundCover/NotFoundCover.js
+++ b/src/views/NotFoundCover/NotFoundCover.js
@@ -128,7 +128,7 @@ const NotFoundCover = () => {
                         component={'img'}
                         loading="lazy"
                         src={
-                          'https://storage.googleapis.com/static.baaahs.org/2013_sheep.jpeg'
+                          'https://static.baaahs.org/Z/2013_sheep.jpeg'
                         }
                         height={{ xs: 'auto', md: 1 }}
                         maxHeight={{ xs: 300, md: 1 }}


### PR DESCRIPTION
Updated large image urls to go through the imgproxy infrastructure. This will reduce their size, although there are still CDN caching issues to be resolved for speed.