### PR TITLE
Fix single page app linking

### DIFF
--- a/src/layouts/Main/components/Topbar/Topbar.js
+++ b/src/layouts/Main/components/Topbar/Topbar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link as RouteLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
@@ -36,20 +37,22 @@ const Topbar = ({ onSidebarOpen, colorInvert = false, data }) => {
         {navItems.map((item, i) => {
           return (
             <Box key={i} marginRight={{ xs: 2, sm: 4 }}>
-              <Link
-                underline="none"
-                component="a"
-                href={item.href}
-                color={colorInvert ? 'common.white' : 'text.primary'}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  fontWeight: 'bold',
-                  textTransform: 'lowercase',
-                }}
-              >
-                {item.title}
-              </Link>
+              <RouteLink to={item.href} style={{ textDecoration: 'none' }}>
+                <Link
+                  underline="none"
+                  component="a"
+                  href={item.href}
+                  color={colorInvert ? 'common.white' : 'text.primary'}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    fontWeight: 'bold',
+                    textTransform: 'lowercase',
+                  }}
+                >
+                  {item.title}
+                </Link>
+              </RouteLink>
             </Box>
           );
         })}


### PR DESCRIPTION
Currently the app is doing a full page load because the links need to be wrapped in the react-router `<Link />` component, but currently only has the MUI `<Link />` component :allofthelinks: